### PR TITLE
Renamed config and color files to examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 Gemfile.lock
 db/nailed.db
 log/nailed.log
+config/config.yml
+config/colors.yml

--- a/config/colors.yml.example
+++ b/config/colors.yml.example
@@ -1,3 +1,5 @@
+### This is an example file! ###
+# the default path to the color file is: config/color.yml
 ---
 line:
   black: "#000000"

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -1,3 +1,5 @@
+### This is an example config! ###
+# the default path to the config file is: config/config.yml
 ---
 debug: # fatal, error, warn, info, debug; defaults to 'fatal'
 logfile: # STDERR, STDOUT, or path; defaults to STDERR


### PR DESCRIPTION
Adjusted .gitignore accordingly. This project is intended to be run on
the live system as git checkout, thus the real config and color files
shouldn't be overwritten, when doing git pull.