### PR TITLE
Fix: Pull products from config not from DB

### DIFF
--- a/bin/app
+++ b/bin/app
@@ -267,9 +267,8 @@ class App < Sinatra::Base
     Nailed::Config.products.each do |_product, values|
       versions = values["versions"]
       versions.each do |version|
-        p = Product.get(version)
-        open = Bugreport.count(product_name: p.name, is_open: true)
-        bugtop << { label: p.name, value: open } unless open == 0
+        open = Bugreport.count(product_name: version, is_open: true)
+        bugtop << { label: version, value: open } unless open == 0
       end unless versions.nil?
     end
     bugtop.to_json


### PR DESCRIPTION
No DB access is necessary here, since the parameter version, with which
the product table gets called, already is the name of the product.