### PR TITLE
Moved: creation/update of the products table

### DIFF
--- a/bin/nailed
+++ b/bin/nailed
@@ -15,16 +15,23 @@ end
 
 abort("try nailed -h") if opts.all? { |_k, v| v.is_a?(FalseClass) }
 
+if Nailed::Config.products.nil?
+  abort("Add some data, there is nothing to be shown")
+else
+  Nailed::Config.products.each do |_product, values|
+    values["versions"].each do |version|
+    db_handler = Product.first_or_create(name: version)
+    Nailed::save_state(db_handler)
+    end unless values["versions"].nil?
+  end
+end
+
 if opts[:server_given]
-  if Nailed::Config.products.nil?
-    abort("Add some data, there is nothing to be shown")
-  else
-    begin
-      `#{File.join(File.expand_path("..", File.dirname(__FILE__)), "bin", "app")}`
-    rescue Interrupt
-      sleep 2
-      exit
-    end
+  begin
+    `#{File.join(File.expand_path("..", File.dirname(__FILE__)), "bin", "app")}`
+  rescue Interrupt
+    sleep 2
+    exit
   end
 end
 

--- a/bin/nailed
+++ b/bin/nailed
@@ -16,7 +16,7 @@ end
 abort("try nailed -h") if opts.all? { |_k, v| v.is_a?(FalseClass) }
 
 if Nailed::Config.products.nil?
-  abort("Add some data, there is nothing to be shown")
+  abort("Config incomplete or missing: Add products to your config.")
 else
   Nailed::Config.products.each do |_product, values|
     values["versions"].each do |version|

--- a/lib/nailed.rb
+++ b/lib/nailed.rb
@@ -42,10 +42,6 @@ module Nailed
   def fill_db_after_migration(github_client)
     Config.products.each do |_product, values|
       organization = values["organization"]
-      values["versions"].each do |version|
-        db_handler = Product.first_or_create(name: version)
-        save_state(db_handler)
-      end unless values["versions"].nil?
       next if organization.nil?
       db_handler = Organization.first_or_create(oname: organization)
       save_state(db_handler)


### PR DESCRIPTION
The config defines the "actual state", which includes the products to
fetch and display. Changing the config shouldn't require a
nailed --migrate, since the database layout didn't change. Because of
this, I moved the code to create/update the products table to the
beginning of the nailed script, so that a simple restart of nailed would
be enough.