### PR TITLE
Changed layout of graphs on index page

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -11,11 +11,12 @@
           Open Pullrequests by Repo
         #pull_top
     .row
-      .col-md-6
+      .col-md-12
         %h3.title{:align => "center"}
           All Bugs
         #allbugs_trend
-      .col-md-6
+    .row
+      .col-md-12
         %h3.title{:align => "center"}
           All Pullrequests
         #allpulls_trend


### PR DESCRIPTION
To adjust for the increased number of data points in the All Bugs graph.
Now every graph sits in its own row, which means the graphs are wider.