### PR TITLE
Refactor: Improving layout of front end tables

### DIFF
--- a/public/css/nailed.css
+++ b/public/css/nailed.css
@@ -2,6 +2,17 @@ body {
   min-height: 2000px;
 }
 
+@media (min-width: 0px) {
+  .container {
+    width: 100%;
+  }
+}
+@media (min-width: 1600px) {
+  .container {
+    width: 70%;
+  }
+}
+
 .navbar-static-top {
   margin-bottom: 19px;
 }
@@ -10,20 +21,22 @@ body {
   border-top: none !important;
 }
 
+.nav.nav-tabs {
+  margin-top: 100px;
+  margin-bottom: 100px;
+  border-bottom: none;
+}
+
 .label-yellow {
   background-color: #FFF176;
   color: black;
 }
 
 td.summary {
-   -ms-word-break: break-all;
-   word-break: break-all;
+  word-wrap: break-word;
+}
 
-   /* Non standard for webkit */
-   word-break: break-word;
-
-   -webkit-hyphens: auto;
-   -moz-hyphens: auto;
-   -ms-hyphens: auto;
-   hyphens: auto;
+td.requestee {
+  width: 16%;
+  word-wrap: break-word;
 }

--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -36,9 +36,9 @@
               %th{:data => {:field => "component", :sortable => "true"}}
                 Component
               %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Creation Time
+                Created at
               %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Last Change Time
+                Changed at
   %div.col-md-12
     %ul.nav.nav-tabs
       %li.active
@@ -59,9 +59,9 @@
                 %th{:data => {:field => "component", :sortable => "true"}}
                   Component
                 %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                  Creation Time
+                  Created at
                 %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                  Last Change Time
+                  Changed at
                 %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
                   needinfo?
         #Bugs.tab-pane
@@ -77,9 +77,9 @@
                 %th{:data => {:field => "component", :sortable => "true"}}
                   Component
                 %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                  Creation Time
+                  Created at
                 %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                  Last Change Time
+                  Changed at
                 %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
                   needinfo?
 

--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -22,10 +22,32 @@
         #bug_status
     .row.no-hide
       - if @top5
-        .col-md-12
-          %h5 Quality Engineering top 5
-          %hr
-          %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/qe_top_5", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+        %h5 Quality Engineering top 5
+        %hr
+        %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/qe_top_5", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+          %thead
+            %tr
+              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
+                Bug Id
+              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
+                Summary
+              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
+                Priority
+              %th{:data => {:field => "component", :sortable => "true"}}
+                Component
+              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
+                Creation Time
+              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
+                Last Change Time
+  %div.col-md-12
+    %ul.nav.nav-tabs
+      %li.active
+        %a{"data-toggle" => "tab", href: '#L3'} L3 List
+      %li
+        %a{"data-toggle" => "tab", href: '#Bugs'} All Bugs
+      .tab-content
+        #L3.tab-pane.active
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenl3", :search => "true", :show => {:refresh => "true", :columns => "true", :cellpadding => "0", :cellspacing => "0"}}}
             %thead
               %tr
                 %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
@@ -40,47 +62,26 @@
                   Creation Time
                 %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
                   Last Change Time
-      .col-md-12
-        %h5 L3 Bugs
-        %hr
-        %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/openl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
-          %thead
-            %tr
-              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
-                Bug Id
-              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
-                Summary
-              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
-                Priority
-              %th{:data => {:field => "component", :sortable => "true"}}
-                Component
-              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Creation Time
-              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Last Change Time
-              %th{:data => {:field => "requestee", :sortable => "true"}}
-                needinfo?
-      %hr
-      .col-md-12
-        %h5 Bugs
-        %hr
-        %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/openwithoutl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
-          %thead
-            %tr
-              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
-                Bug Id
-              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
-                Summary
-              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
-                Priority
-              %th{:data => {:field => "component", :sortable => "true"}}
-                Component
-              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Creation Time
-              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Last Change Time
-              %th{:data => {:field => "requestee", :sortable => "true"}}
-                needinfo?
+                %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
+                  needinfo?
+        #Bugs.tab-pane
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenwithoutl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+            %thead
+              %tr
+                %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
+                  Bug Id
+                %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
+                  Summary
+                %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
+                  Priority
+                %th{:data => {:field => "component", :sortable => "true"}}
+                  Component
+                %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Creation Time
+                %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Last Change Time
+                %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
+                  needinfo?
 
 != js :jquery
 != js :jqueryplugin

--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -2,13 +2,11 @@
 .container
   %div.col-md-12.main
     .row
-      .col-md-12
-        %h1.page-header
-          #{@product}
+      %h1.page-header
+        #{@product}
     .row
-      .col-md-12
-        %h5 Bug Trends
-        #bug_trend
+      %h5 Bug Trends
+      #bug_trend
     .row
       .col-md-6
         %h5 Bug Priorities

--- a/views/github.haml
+++ b/views/github.haml
@@ -19,7 +19,7 @@
               %th{:data => {:field => "title", :sortable => "true", :class => "summary"}}
                 Summary
               %th{:data => {:field => "created_at", :sortable => "true", :formatter => "timestampReduce"}}
-                Creation Time
+                Created at
 
 != js :jquery
 != js :jqueryplugin

--- a/views/index.haml
+++ b/views/index.haml
@@ -10,75 +10,72 @@
         %h3.title{:align => "center"}
           Open Pullrequests by Repo
         #pull_top
+  %div.col-md-12
     .row
-      .col-md-12
-        %h3.title{:align => "center"}
-          All Bugs
-        #allbugs_trend
+      %h3.title{:align => "center"}
+        All Bugs
+      #allbugs_trend
     .row
-      .col-md-12
-        %h3.title{:align => "center"}
-          All Pullrequests
-        #allpulls_trend
+      %h3.title{:align => "center"}
+        All Pullrequests
+      #allpulls_trend
     .row
-      .col-md-12
-        %h3.title{:align => "center"}
-          All L3 Bugs
-        #l3_trend
-    %br
-    .row
-      .col-md-12
-        %hr
-        %h5 L3 List
-        %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
-          %thead
-            %tr
-              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
-                Bug Id
-              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
-                Summary
-              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
-                Priority
-              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Created at
-              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Changed at
-              %th{:data => {:field => "requestee", :sortable => "true"}}
-                needinfo?
-    .row
-      .col-md-12
-        %hr
-        %h5 Bugs
-        %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenwithoutl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
-          %thead
-            %tr
-              %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
-                Bug Id
-              %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
-                Summary
-              %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
-                Priority
-              %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Created at
-              %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
-                Changed at
-              %th{:data => {:field => "requestee", :sortable => "true"}}
-                needinfo?
-    .row
-      .col-md-12
-        %hr
-        %h5 Open Pull Requests
-        %table{:data => {:toggle => "table", :url => "/json/github/allopenpulls", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
-          %thead
-            %tr
-              %th{:data => {:field => "url", :sortable => "true", :formatter => "githubFromLink"}}
-                Number
-              %th{:data => {:field => "title", :sortable => "true", :class => "summary"}}
-                Summary
-              %th{:data => {:field => "repository_rname", :sortable => "true"}}
-                Repository
-              %th{:data => {:field => "created_at", :sortable => "true", :formatter => "timestampReduce"}}
-                Created at
+      %h3.title{:align => "center"}
+        All L3 Bugs
+      #l3_trend
+  %div.col-md-12
+    %ul.nav.nav-tabs
+      %li.active
+        %a{"data-toggle" => "tab", href: '#L3'} L3 List
+      %li
+        %a{"data-toggle" => "tab", href: '#Bugs'} All Bugs
+      %li
+        %a{"data-toggle" => "tab", href: '#PRs'} Pull Requests
+      .tab-content
+        #L3.tab-pane.active
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenl3", :search => "true", :show => {:refresh => "true", :columns => "true", :cellpadding => "0", :cellspacing => "0"}}}
+            %thead
+              %tr
+                %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
+                  Bug Id
+                %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
+                  Summary
+                %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
+                  Priority
+                %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Created at
+                %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Changed at
+                %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
+                  needinfo?
+        #Bugs.tab-pane
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenwithoutl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+            %thead
+              %tr
+                %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
+                  Bug Id
+                %th{:data => {:field => "summary", :sortable => "true", :class => "summary"}}
+                  Summary
+                %th{:data => {:field => "priority", :sortable => "true", :formatter => "bugzillaPriority"}}
+                  Priority
+                %th{:data => {:field => "creation_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Created at
+                %th{:data => {:field => "last_change_time", :sortable => "true", :formatter => "timestampReduce"}}
+                  Changed at
+                %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
+                  needinfo?
+        #PRs.tab-pane
+          %table{:data => {:toggle => "table", :url => "/json/github/allopenpulls", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+            %thead
+              %tr
+                %th{:data => {:field => "url", :sortable => "true", :formatter => "githubFromLink"}}
+                  Number
+                %th{:data => {:field => "title", :sortable => "true", :class => "summary"}}
+                  Summary
+                %th{:data => {:field => "repository_rname", :sortable => "true"}}
+                  Repository
+                %th{:data => {:field => "created_at", :sortable => "true", :formatter => "timestampReduce"}}
+                  Created at
 
 != js :jquery
 != js :jqueryplugin


### PR DESCRIPTION
The tables showing 'L3 bugs', 'all bugs' and 'open pull requests' were
moved into an interactive tab menu, showing only one table at a time.
This avoids unnecessary scrolling to find the other tables.

The container size was increased to 70% of the page (if available) to
accommodate the previously added needinfo? column.

Newlines in the bug summary column won't break words anymore, expect
for very long words, thus avoiding confusion by weirdly breaking
technical terms over two lines.