### PR TITLE
 Fix: Show only bugs of product on product page

### DIFF
--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -40,9 +40,9 @@
   %div.col-md-12
     %ul.nav.nav-tabs
       %li.active
-        %a{"data-toggle" => "tab", href: '#L3'} L3 List
+        %a{"data-toggle" => "tab", href: '#L3'} L3 Bugs
       %li
-        %a{"data-toggle" => "tab", href: '#Bugs'} All Bugs
+        %a{"data-toggle" => "tab", href: '#Bugs'} Non L3 Bugs
       .tab-content
         #L3.tab-pane.active
           %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/openl3", :search => "true", :show => {:refresh => "true", :columns => "true", :cellpadding => "0", :cellspacing => "0"}}}

--- a/views/bugzilla.haml
+++ b/views/bugzilla.haml
@@ -45,7 +45,7 @@
         %a{"data-toggle" => "tab", href: '#Bugs'} All Bugs
       .tab-content
         #L3.tab-pane.active
-          %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenl3", :search => "true", :show => {:refresh => "true", :columns => "true", :cellpadding => "0", :cellspacing => "0"}}}
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/openl3", :search => "true", :show => {:refresh => "true", :columns => "true", :cellpadding => "0", :cellspacing => "0"}}}
             %thead
               %tr
                 %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}
@@ -63,7 +63,7 @@
                 %th{:data => {:field => "requestee", :sortable => "true", :class => "requestee"}}
                   needinfo?
         #Bugs.tab-pane
-          %table{:data => {:toggle => "table", :url => "/json/bugzilla/allopenwithoutl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
+          %table{:data => {:toggle => "table", :url => "/json/bugzilla/#{@product_}/openwithoutl3", :search => "true", :show => {:refresh => "true", :columns => "true"}}}
             %thead
               %tr
                 %th{:data => {:field => "url", :sortable => "true", :formatter => "bugzillaFromLink"}}


### PR DESCRIPTION
This restores previous functionality, which got bugged with a previous
commit: cd75227

On the nailed bugzilla subpages of a specific product, only bugs related to
this product should be shown in the bug tables.

Also adjusts table names to better reflect the content.

This fixes: https://github.com/openSUSE/nailed/issues/55