### PR TITLE
Adjust: Increase number of data points in trends

### DIFF
--- a/app.rb
+++ b/app.rb
@@ -53,7 +53,7 @@ class App < Sinatra::Base
       when :bug
         table = "bugtrends"
         sql_statement =
-          if Bugtrend.count(product_name: item) > 20
+          if Bugtrend.count(product_name: item) > 40
             "SELECT (SELECT COUNT(0) " \
             "FROM #{table} t1 " \
             "WHERE t1.rowid <= t2.rowid " \
@@ -63,7 +63,7 @@ class App < Sinatra::Base
             "WHERE product_name = '#{item}' " \
             "AND (tmp_id % ((SELECT COUNT(*) " \
             "FROM #{table} " \
-            "WHERE product_name = '#{item}')/20) = 0) " \
+            "WHERE product_name = '#{item}')/40) = 0) " \
             "ORDER BY time"
           else
             "SELECT time, open, fixed " \


### PR DESCRIPTION
Increases the number of data points for product specific bug trends from
20 to 40, so that more accurate data can be read from the graph.