### PR TITLE
Add: Caching for trend helper function

### DIFF
--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -5,6 +5,7 @@ debug: # fatal, error, warn, info, debug; defaults to 'fatal'
 logfile: # STDERR, STDOUT, or path; defaults to STDERR
 title: # Give me a name, or (default) call me Dashboard
 port: # Specify a port where you can reach the webinterface, or (default) 4567
+cache-threshold: # Specify how long specifig routes get cached in seconds (default: 6 hours)
 netrc: # true or false (default). For private GitHub repos you will need to use a .netrc
 bugzilla: # Url of your Bugzilla instance
 products: # list of exact product names as they appear on bugzilla


### PR DESCRIPTION
* because the DB interaction on the trend call is very slow and
  noticeably delayed on the page load, which caused reformatting
  issues, when the graph was finally drawn

* with a general purpose cache class, which could be used for other
  functions as well, if needed