### PR TITLE
 Refactor: Github fetch to be more efficient

### DIFF
--- a/lib/nailed/bugzilla.rb
+++ b/lib/nailed/bugzilla.rb
@@ -109,12 +109,12 @@ module Nailed
 
     def remove_stale_bugs
       Bugreport.select(:bug_id, :fetched_at).each do |bug|
-        if (Time.now - bug.fetched_at > 60 * 60 * 24)
+        if (Time.now - bug.fetched_at > 86400) # stale for 1 day
           begin
             bug.destroy
             Nailed.logger.info("#{__method__}: bug_id: ##{bug.bug_id}")
           rescue Exception => e
-            Nailed.logger.error("#{__Method__}: Can't remove bug ##{bug.bug_id}")
+            Nailed.logger.error("#{__Method__}: Can't remove bug ##{bug.bug_id}: #{e}")
           end
         end
       end


### PR DESCRIPTION
Improvements:
* now fetches only `open` pullrequests
* closes all pullrequests, which weren't updated by the fetch
* fetch takes less than 1 minute now, compared to previous 5 - 15
  minutes, depending on system

Implications:
* it is now impossible to fetch ALL pullrequests without touching the
  code
* pullrequests opened and closed inbetween fetch intervalls will
  be missed completely

But both these implications should not matter, because the frontend only
tracks closed bugs not closed pull requests, even though the backend had
technically much more information. So from the perspective of website
functionality, nothing should change.