### PR TITLE
Update gems to newest available versions

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source "https://rubygems.org"
 
 # back-end
-gem "trollop", "2.1.2"
+gem "trollop", "2.1.3"
 gem "bicho", "0.0.16"
-gem "octokit", "4.9.0"
-gem "sequel", "5.8.0"
+gem "octokit", "4.10.0"
+gem "sequel", "5.11.0"
 gem "sqlite3", "1.3.13"
 gem "netrc", "0.11.0"
 # front-end
-gem "sinatra", "2.0.1"
-gem "sprockets", "3.7.1"
+gem "sinatra", "2.0.3"
+gem "sprockets", "3.7.2"
 gem "haml", "5.0.4"
-gem "puma", "3.11.4"
+gem "puma", "3.12"


### PR DESCRIPTION
* Nokogiri now throws a warning, because it was build against LibXML
  version 2.9.8, but Leap 15 uses 2.9.7, but no issues were observed