### PR TITLE
Add component option

### DIFF
--- a/assets/javascript/nailed/index.js
+++ b/assets/javascript/nailed/index.js
@@ -35,7 +35,7 @@ function index(colors, product_query, org_query){
       if (/Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent))
         jQuery.noop();
       else
-        window.open("/"+row.label.replace(/ /g,'_')+"/bugzilla","_self");
+        window.open("/"+row.label.replace(/ /g,'_').split('/')[0]+"/bugzilla","_self");
     });
   });
   $.getJSON("/json/bugzilla/trend/allopenl3", function (json) {

--- a/config/config.yml.example
+++ b/config/config.yml.example
@@ -11,6 +11,10 @@ bugzilla: # Url of your Bugzilla instance
 products: # list of exact product names as they appear on bugzilla
   - example_product_1
   - example_product_2
+  - example_product_3:
+    components: # if you want to filter the given product by components
+    - example_component_1
+    - example_component_2
 organizations: # here you add the github repos you care about
   - name: opensuse
     repositories:

--- a/lib/nailed/bugzilla.rb
+++ b/lib/nailed/bugzilla.rb
@@ -13,9 +13,11 @@ module Nailed
     def get_bugs
       Nailed::Config.products.each do |product|
         Nailed.logger.info("#{__method__}: Fetching bugs for #{product}")
+        components = Nailed::Config.components[product]
+        query = components.nil? ? {product: product} : {product: product, component: components}
         begin
           retries ||= 0
-          Bicho::Bug.where(product: product).each do |bug|
+          Bicho::Bug.where(query).each do |bug|
             attributes = {
               bug_id:           bug.id,
               summary:          bug.summary,

--- a/lib/nailed/config.rb
+++ b/lib/nailed/config.rb
@@ -35,7 +35,18 @@ module Nailed
 
       # attr_accessor:
       def products
-        load_content['products']
+        @@components = Hash.new
+        products = load_content['products'].clone
+        products.each_index do |x|
+          if products[x].class == Hash
+            hash_components(products[x])
+            products[x] = products[x].keys.first
+          end
+        end
+      end
+
+      def components
+        @@components
       end
 
       def organizations
@@ -51,6 +62,10 @@ module Nailed
       end
 
       private
+
+      def hash_components(product)
+        @@components[product.keys.first]=product.values.last unless product.fetch("components",nil).nil?
+      end
 
       def load_content
         path_to_config ||= File.join(__dir__, "..", "..", "config", "config.yml")

--- a/views/layout.haml
+++ b/views/layout.haml
@@ -21,7 +21,7 @@
               %ul.dropdown-menu{:role => 'menu'}
                 - @products.each do |product|
                   %li
-                    %a{:href => "/#{product.gsub(/ /,'_')}/bugzilla"} #{product}
+                    %a{:href => "/#{product.gsub(/ /,'_')}/bugzilla"} #{get_label(product)}
             %li.dropdown
               %a.dropdown-toggle{:role => 'button', :data => {:toggle => 'dropdown'}, :href => '/'}
                 Github


### PR DESCRIPTION
Add the possibility to filter by product component.
Edit the routes to function with the new feature.
If only one component per product is selected show
the open bugs by product as product/component.
With multiple ones show as product/subset.

Simply add the desired components to your config.yml
Syntax example:

```
products:
  - openSUSE Tumbleweed:
    components:
      - Kubic
      - KVM
  - SUSE CaaS Platform 2
```
Fixes: #68
Signed-off-by: Pascal Arlt <parlt@suse.com>