### PR TITLE
[Bugfix] Git Repos not displayed in PR table

### DIFF
--- a/views/index.haml
+++ b/views/index.haml
@@ -72,7 +72,7 @@
                   Number
                 %th{:data => {:field => "title", :sortable => "true", :class => "summary"}}
                   Summary
-                %th{:data => {:field => "repository_rname", :sortable => "true"}}
+                %th{:data => {:field => "rname", :sortable => "true"}}
                   Repository
                 %th{:data => {:field => "created_at", :sortable => "true", :formatter => "timestampReduce"}}
                   Created at


### PR DESCRIPTION
Fixes a bug that causes git repositories to not be
displayed in the pull requests table on the index page.

Signed-off-by: Pascal Arlt <parlt@suse.com>