### PR TITLE
Update gems to most recent version

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,14 +1,14 @@
 source "https://rubygems.org"
 
 # back-end
-gem "trollop", "2.1.3"
-gem "bicho", "0.0.16"
-gem "octokit", "4.10.0"
-gem "sequel", "5.11.0"
+gem "optimist", "3.0.0"
+gem "bicho", "0.0.17"
+gem "octokit", "4.13.0"
+gem "sequel", "5.14.0"
 gem "sqlite3", "1.3.13"
 gem "netrc", "0.11.0"
 # front-end
-gem "sinatra", "2.0.3"
+gem "sinatra", "2.0.4"
 gem "sprockets", "3.7.2"
 gem "haml", "5.0.4"
 gem "puma", "3.12"

--- a/bin/nailed
+++ b/bin/nailed
@@ -1,9 +1,9 @@
 #!/usr/bin/env ruby
 
-require 'trollop'
+require 'optimist'
 require_relative "../lib/nailed"
 
-opts = Trollop.options do
+opts = Optimist.options do
   opt :new, "Create new database", short: "n"
   opt :migrate, "Migrate/Upgrade database", short: "m"
   opt :bugzilla, "Refresh bugzilla database records", short: "b"

--- a/nailed.gemspec
+++ b/nailed.gemspec
@@ -1,3 +1,4 @@
+# OUTDATED, DO NOT USE ANYMORE!
 require_relative "lib/nailed/version"
 
 Gem::Specification.new do |s|


### PR DESCRIPTION
* swap the now deprecated `trollop` for its official succesor `optimist`
* add a warning to `nailed.gemspec` since it is outdated and
  unmaintained